### PR TITLE
Check validity of file descriptor before sending message to it.

### DIFF
--- a/src/SocketIO.php
+++ b/src/SocketIO.php
@@ -165,7 +165,10 @@ class SocketIO implements OnMessageInterface, OnOpenInterface, OnCloseInterface
                             'type' => Packet::ACK,
                             'data' => $data,
                         ]);
-                        $this->sender->push($frame->fd, Engine::MESSAGE . $this->encoder->encode($responsePacket));
+
+                        if ($this->sender->check()) {
+                            $this->sender->push($frame->fd, Engine::MESSAGE . $this->encoder->encode($responsePacket));
+                        }
                     };
                 }
                 $this->dispatch($frame->fd, $packet->nsp, ...$packet->data);


### PR DESCRIPTION
This fixes: Warning: Swoole\WebSocket\Server::push(): session#PD does not exists in /var/www/vendor/hyperf/socketio-server/src/SocketIO.php on line 166