### PR TITLE
fix: 修复getAuth方法返回值和Subscriber参数不一致问题

### DIFF
--- a/src/Room/RedisAdapter.php
+++ b/src/Room/RedisAdapter.php
@@ -334,7 +334,7 @@ class RedisAdapter implements AdapterInterface, EphemeralInterface
         $sub = make(Subscriber::class, [
             'host' => $this->redis->getHost(),
             'port' => $this->redis->getPort(),
-            'password' => $this->redis->getAuth(),
+            'password' => $this->redis->getAuth() ?: '',
             'timeout' => 5,
         ]);
         $prefix = $this->redis->getOption(Redis::OPT_PREFIX);


### PR DESCRIPTION
[ERROR] TypeError: Mix\Redis\Subscriber\Subscriber::__construct(): Argument #3 ($password) must be of type string, null given, called in hyperf/di/src/Resolver/ObjectResolver.php on line 84 and defined in vendor/mix/redis-subscriber/src/Subscriber.php:65
