### PR TITLE
Fixed bug that Entry Hyperf\SocketIOServer\Emitter\Future cannot be resolved: Parameter $opcode of __construct() has no value defined or guessable

### DIFF
--- a/src/Emitter/Future.php
+++ b/src/Emitter/Future.php
@@ -35,8 +35,6 @@ class Future
         private string $event,
         private array $data,
         callable $encode,
-        private int $opcode,
-        private int $flag,
         private ?FrameInterface $frame = null
     ) {
         $this->id = '';
@@ -72,10 +70,6 @@ class Future
         }
         $message = ($this->encode)($this->id, $this->event, $this->data);
         $this->sent = true;
-        if ($this->frame) {
-            $this->sender->pushFrame($this->fd, $this->frame->setPayloadData($message));
-        } else {
-            $this->sender->pushFrame($this->fd, new Frame(opcode: $this->opcode, payloadData: $message));
-        }
+        $this->sender->pushFrame($this->fd, $this->frame->setPayloadData($message));
     }
 }


### PR DESCRIPTION
Fixed bug that Entry `Hyperf\SocketIOServer\Emitter\Future` cannot be resolved: Parameter $opcode of __construct() has no value defined or guessable.
<img width="1549" alt="image" src="https://github.com/hyperf/socketio-server/assets/110524397/158fe1d2-c37f-4444-908a-5eafbefcb070">
